### PR TITLE
fix: add Close method

### DIFF
--- a/statsd/datadog_backend.go
+++ b/statsd/datadog_backend.go
@@ -60,3 +60,7 @@ func (b *datadogBackend) Set(_ context.Context, name string, value string, tags 
 func (b *datadogBackend) Timing(_ context.Context, name string, value time.Duration, tags []string, rate float64) error {
 	return b.client.Timing(name, value, tags, rate)
 }
+
+func (b *datadogBackend) Close() error {
+	return b.client.Close()
+}

--- a/statsd/forwarding_backend.go
+++ b/statsd/forwarding_backend.go
@@ -41,3 +41,7 @@ func (b *forwardingBackend) Set(ctx context.Context, name string, value string, 
 func (b *forwardingBackend) Timing(ctx context.Context, name string, value time.Duration, tags []string, rate float64) error {
 	return b.handler(ctx, "timing", name, value, tags, rate)
 }
+
+func (b *forwardingBackend) Close() error {
+	return nil
+}

--- a/statsd/mocks/Backend.go
+++ b/statsd/mocks/Backend.go
@@ -95,3 +95,17 @@ func (_m *Backend) Timing(ctx context.Context, name string, value time.Duration,
 
 	return r0
 }
+
+// Close provides a mock function
+func (_m *Backend) Close() error {
+	ret := _m.Called()
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func() error); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}

--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -34,6 +34,8 @@ type Backend interface {
 	Set(ctx context.Context, name string, value string, tags []string, rate float64) error
 	// Timing sends timing information, it is an alias for TimeInMilliseconds
 	Timing(ctx context.Context, name string, value time.Duration, tags []string, rate float64) error
+	// Close closes the connection to the statsd server.
+	Close() error
 }
 
 var currentBackend = NewNullBackend()

--- a/statsd/statsd_test.go
+++ b/statsd/statsd_test.go
@@ -12,6 +12,10 @@ func TestBackend(t *testing.T) {
 	dd, err := NewDatadogBackend("localhost:8125", "catwalk", []string{"global:tag"})
 	require.NoError(t, err)
 
+	defer func() {
+		dd.Close()
+	}()
+
 	tests := []struct {
 		impl string
 		exp  Backend


### PR DESCRIPTION
This enable flushing correctly the metrics

By default, metrics are buffered and sent to Datadog every 100ms

If we are for example shutting down an app, some metrics might be lost

By Closing it properly, we ensure every metrics will be actually sent